### PR TITLE
Add requiresDependencyResolution=compile to JAXRSAnalyzerMojo

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/maven/JAXRSAnalyzerMojo.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/maven/JAXRSAnalyzerMojo.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
  * @author Sebastian Daschner
  * @goal analyze-jaxrs
  * @phase process-classes
+ * @requiresDependencyResolution compile
  */
 public class JAXRSAnalyzerMojo extends AbstractMojo {
 


### PR DESCRIPTION
This adds all classes needed for compilation to the analysis scope.
Previously not all classes were considered by the JAXRSAnalyzerMojo
which lead to execeptions during build.