### PR TITLE
Add support for multiple backends

### DIFF
--- a/Documentation.adoc
+++ b/Documentation.adoc
@@ -17,6 +17,7 @@ To enable the plugin, simply add these lines to your pom.xml in the `<plugins>` 
             </goals>
             <configuration>
                 <!-- Available backends are plaintext (default), swagger and asciidoc -->
+                <!-- Also supported is a comma separated list. E.g. `swagger,asciidoc` -->
                 <backend>plaintext</backend>
                 <!-- Domain of the deployed project, defaults to "" -->
                 <deployedDomain>example.com</deployedDomain>
@@ -41,6 +42,7 @@ After building your project, the documentation resides under 'target/jaxrs-analy
 === Backend
 The `backend` parameter specifies the output format of the analysis.
 The available formats are Plaintext, AsciiDoc and Swagger.
+Support multiple backends as comma separated list (e.g. `<backend>asciidoc,swagger</backend>`)
 
 For further use of the created formats see the https://github.com/sdaschner/jaxrs-analyzer/blob/master/Documentation.adoc[JAX-RS Analyzer documentation].
 

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/maven/BackendType.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/maven/BackendType.java
@@ -1,5 +1,10 @@
 package com.sebastian_daschner.jaxrs_analyzer.maven;
 
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+
 /**
  * The backend types available for the Maven plugin.
  *
@@ -23,4 +28,12 @@ enum BackendType {
         return fileLocation;
     }
 
+  public static BackendType fromString(String value) {
+      try {
+        return BackendType.valueOf(value.toUpperCase(Locale.US));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Backend " + value + " not valid! Valid values are: " +
+                Stream.of(BackendType.values()).map(Enum::name).map(String::toLowerCase).collect(joining(", ")));
+      }
+  }
 }


### PR DESCRIPTION
Add support for multiple backends as comma separated list (e.g. `<backend>asciidoc,swagger</backend>`).
Would be really nice if this would be merged as I had several projects were we required the `swagger` as downloadable documentation and `asciidoc` for the _wiki documentation_.

Btw. either some dependency is locally wrong on my machine or the `swaggerSchemes` implementation does not support values as comma separated list (in combination with `String[]`).
At least I got an error if I tried to set `http,https`.